### PR TITLE
Single connection, parallel goroutines for RX/TX, error handling

### DIFF
--- a/ws/wsclient.go
+++ b/ws/wsclient.go
@@ -12,7 +12,7 @@ import (
 	"github.com/net-byte/vtun/common/netutil"
 	"github.com/net-byte/vtun/tun"
 	"github.com/songgao/water"
-	"github.com/songgao/water/waterutil"
+	//"github.com/songgao/water/waterutil"
 )
 
 // Start websocket client
@@ -34,18 +34,13 @@ func StartClient(config config.Config) {
 func wsToTun(wg *sync.WaitGroup, config config.Config, wsconn net.Conn, iface *water.Interface) {
 	defer wg.Done()
 	for {
-		var packet []byte
-		var err error
 		wsconn.SetReadDeadline(time.Now().Add(time.Duration(config.Timeout) * time.Second))
-		packet, err = wsutil.ReadServerBinary(wsconn)
+		packet, err := wsutil.ReadServerBinary(wsconn)
 		if err != nil {
 			break
 		}
 		if config.Obfs {
 			packet = cipher.XOR(packet)
-		}
-		if !waterutil.IsIPv4(packet) {
-			continue
 		}
 		iface.Write(packet)
 	}
@@ -53,26 +48,18 @@ func wsToTun(wg *sync.WaitGroup, config config.Config, wsconn net.Conn, iface *w
 
 func tunToWs(wg *sync.WaitGroup, config config.Config, wsconn net.Conn, iface *water.Interface) {
 	defer wg.Done()
-	packet := make([]byte, 0, config.MTU)
+	packet := make([]byte, config.MTU)
 	for {
 		n, err := iface.Read(packet)
 		if err != nil || n == 0 {
 			break
 		}
-		packet = packet[:n]
-		if !waterutil.IsIPv4(packet) {
-			continue
-		}
-		srcIPv4, dstIPv4 := netutil.GetIPv4(packet)
-		if srcIPv4 == "" || dstIPv4 == "" {
-			continue
-		}
+		b := packet[:n]
 		if config.Obfs {
 			packet = cipher.XOR(packet)
 		}
 		wsconn.SetWriteDeadline(time.Now().Add(time.Duration(config.Timeout) * time.Second))
-		err = wsutil.WriteClientBinary(wsconn, packet)
-		if err != nil {
+		if err = wsutil.WriteClientBinary(wsconn, b); err != nil {
 			break
 		}
 	}


### PR DESCRIPTION
Fixes some problems introduced in https://github.com/net-byte/vtun/pull/11:
- Packet size slicing
- Write timeouts
- len(s) used by iface.Read() instead of cap(s)

and also fixes some chokes where the tunnel becomes unresponsive because it doesn't respond to packets other than IPv4 