### PR TITLE
Remove application data race, after send shutdown signal

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -26,26 +26,35 @@ A simple VPN written in Go.
 var _srcUrl = "https://github.com/net-byte/vtun"
 
 // vtun app struct
-type Vtun struct {
+type App struct {
 	Config  *config.Config
 	Version string
 	Iface   *water.Interface
 }
 
+func NewApp(config *config.Config, version string) *App {
+
+	return &App{
+		Config:  config,
+		Version: version,
+	}
+}
+
 // InitConfig initializes the config
-func (app *Vtun) InitConfig() {
+func (app *App) InitConfig() {
 	log.Printf(_banner, _srcUrl)
 	log.Printf("vtun version %s", app.Version)
 	if !app.Config.ServerMode {
 		app.Config.LocalGateway = netutil.GetLocalGateway()
 	}
 	cipher.SetKey(app.Config.Key)
+	app.Iface = tun.CreateTun(*app.Config)
 	log.Printf("initialized config: %+v", app.Config)
 }
 
 // StartApp starts the app
-func (app *Vtun) StartApp() {
-	app.Iface = tun.CreateTun(*app.Config)
+func (app *App) StartApp() {
+
 	switch app.Config.Protocol {
 	case "udp":
 		if app.Config.ServerMode {
@@ -81,7 +90,7 @@ func (app *Vtun) StartApp() {
 }
 
 // StopApp stops the app
-func (app *Vtun) StopApp() {
+func (app *App) StopApp() {
 	tun.ResetTun(*app.Config)
 	app.Iface.Close()
 	log.Println("vtun stopped")

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.StringVar(&config.TLSSni, "sni", "", "tls handshake sni")
 	flag.BoolVar(&config.TLSInsecureSkipVerify, "isv", false, "tls insecure skip verify")
 	flag.Parse()
-	app := &app.Vtun{Config: &config, Version: _version}
+	app := app.NewApp(&config, _version)
 	app.InitConfig()
 	go app.StartApp()
 	quit := make(chan os.Signal, 1)


### PR DESCRIPTION
Hello.

compile with race:
``CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -race -o ./bin/vtun-linux-amd64 ./main.go```
run app and stop (CTRL+C)
This pull request fix issue