### PR TITLE
kcp client support reconnect

### DIFF
--- a/kcp/kcpclient.go
+++ b/kcp/kcpclient.go
@@ -2,7 +2,9 @@ package kcp
 
 import (
 	"crypto/sha1"
+	"errors"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/golang/snappy"
@@ -27,6 +29,7 @@ func StartClient(iface *water.Interface, config config.Config) {
 	go tunToKcp(config, iface)
 	for {
 		if session, err := kcp.DialWithOptions(config.ServerAddr, block, 10, 3); err == nil {
+		        go CheckKCPSessionAlive(session, config)
 			cache.GetCache().Set("kcpconn", session, 24*time.Hour)
 			kcpToTun(config, session, iface)
 			cache.GetCache().Delete("kcpconn")
@@ -126,5 +129,20 @@ func kcpToTun(config config.Config, session *kcp.UDPSession, iface *water.Interf
 			break
 		}
 		counter.IncrReadBytes(n)
+	}
+}
+
+func CheckKCPSessionAlive(session *kcp.UDPSession, config config.Config) {
+	for {
+		time.Sleep(time.Duration(config.Timeout) * time.Second)
+
+		result := netutil.ExecCmd("ping", "-c", "4", config.ServerIP)
+		// macos return "100.0% packet loss",  linux return "100% packet loss"
+		if strings.Contains(result, `100.0%`) || strings.Contains(result, `100%`) {
+			session.Close()
+			netutil.PrintErr(errors.New("ping server failed, reconnecting"), config.Verbose)
+			break
+		}
+
 	}
 }

--- a/kcp/kcpclient.go
+++ b/kcp/kcpclient.go
@@ -137,7 +137,7 @@ func CheckKCPSessionAlive(session *kcp.UDPSession, config config.Config) {
 		time.Sleep(time.Duration(config.Timeout) * time.Second)
 
 		result := netutil.ExecCmd("ping", "-c", "4", config.ServerIP)
-		// macos return "100.0% packet loss",  linux return "100% packet loss"
+		// macos return "100.0% packet loss",  windows and linux return "100% packet loss"
 		if strings.Contains(result, `100.0%`) || strings.Contains(result, `100%`) {
 			session.Close()
 			netutil.PrintErr(errors.New("ping server failed, reconnecting"), config.Verbose)


### PR DESCRIPTION
**问题：**
使用kcp协议时，服务端重启后客户端无法自动重连

**复现：**
1.客户端连接上后，一直ping服务端。此时icmp包可以收到响应
2.重启服务端，客户端所有icmp均无响应
参考 https://github.com/skywind3000/kcp/issues/176
@skywind3000 给的建议做一个定期ping检查kcp连接是否断开。

**修改后**
1.客户端连接上后，一直ping服务端。此时icmp包可以收到响应
2.重启服务端，客户端所有icmp均无响应
3.达到timeout后，close掉kcp session，然后与服务端新建立一个kcp session
4.icmp包可以收到响应