### PR TITLE
fix ipv6 address parse issue in wsserver /ip response.

### DIFF
--- a/ws/wsserver.go
+++ b/ws/wsserver.go
@@ -52,7 +52,7 @@ func StartServer(iFace *water.Interface, config config.Config) {
 	http.HandleFunc("/ip", func(w http.ResponseWriter, req *http.Request) {
 		ip := req.Header.Get("X-Forwarded-For")
 		if ip == "" {
-			ip = strings.Split(req.RemoteAddr, ":")[0]
+			ip, _, _ = net.SplitHostPort(req.RemoteAddr)
 		}
 		resp := fmt.Sprintf("%v", ip)
 		io.WriteString(w, resp)


### PR DESCRIPTION
Thanks for your good job and nice project \w water, vtun and more.

I found a bit issue about wsserver ...

```sh
~$ curl http://[vtun-server]:3001/ip
[
```

When `req.RemoteAddr` contains IPv6 address, it will have colons(:), To fix this issue, we should use `net.SplitHostPort` to handle this as an expected.