### PR TITLE
fix: improve tag field key readablity of `config.go` struct

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -11,9 +11,9 @@ type Config struct {
 	LocalAddr                 string `json:"local_addr"`
 	ServerAddr                string `json:"server_addr"`
 	ServerIP                  string `json:"server_ip"`
-	ServerIPv6                string `json:"server_i_pv_6"`
+	ServerIPv6                string `json:"server_ipv6"`
 	CIDR                      string `json:"cidr"`
-	CIDRv6                    string `json:"cid_rv_6"`
+	CIDRv6                    string `json:"cidr_ipv6"`
 	Key                       string `json:"key"`
 	Protocol                  string `json:"protocol"`
 	Path                      string `json:"path"`
@@ -24,7 +24,7 @@ type Config struct {
 	MTU                       int    `json:"mtu"`
 	Timeout                   int    `json:"timeout"`
 	LocalGateway              string `json:"local_gateway"`
-	LocalGatewayv6            string `json:"local_gatewayv_6"`
+	LocalGatewayv6            string `json:"local_gateway_ipv6"`
 	TLSCertificateFilePath    string `json:"tls_certificate_file_path"`
 	TLSCertificateKeyFilePath string `json:"tls_certificate_key_file_path"`
 	TLSSni                    string `json:"tls_sni"`


### PR DESCRIPTION
After [adding support for the config file](https://github.com/net-byte/vtun/pull/84), the field keys in the Config struct tag become significant for users, as they use these fields to write up their configuration.

Our [config.go](https://github.com/net-byte/vtun/blob/master/common/config/config.go) file contains fields like`server_i_pv_6`, `cid_rv_6`, and `local_gatewayv_6`. These appear to have been generated by some code tools.

I have renamed these to improve readability.